### PR TITLE
[SERD-1694] Service Client method

### DIFF
--- a/civis/__init__.py
+++ b/civis/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from civis._version import __version__
 from civis.civis import APIClient, find, find_one
 from civis import io, ml, parallel, utils
+from civis.service_client import ServiceClient
 
 __all__ = ["__version__", "APIClient", "find", "find_one", "io",
-           "ml", "parallel", "utils"]
+           "ml", "parallel", "utils", "ServiceClient"]

--- a/civis/resources/_resources.py
+++ b/civis/resources/_resources.py
@@ -409,7 +409,7 @@ def parse_method_name(verb, path):
 def parse_method(verb, operation, path):
     """ Generate a python function from a specification of that function."""
     summary = operation["summary"]
-    params = operation["parameters"]
+    params = operation.get("parameters", [])
     responses = operation["responses"]
     deprecated = operation.get('deprecated', False)
     if 'deprecated' in summary.lower() or deprecated:

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -134,6 +134,6 @@ class ServiceClient():
             service = client.services.get(self._service_id)
         except CivisAPIError as err:
             msg = ('There was an issue '
-                   'finding service with ID {}.').format(service_id)
+                   'finding service with ID {}.').format(self._service_id)
             six.raise_from(ValueError(msg), err)
         return service['current_url']

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -7,22 +7,18 @@ import warnings
 from jsonref import JsonRef
 import six
 
-from civis.base import Endpoint, CivisAPIError, CivisAPIKeyError, tostr_urljoin
+from civis.base import Endpoint, CivisAPIError, tostr_urljoin
 from civis.resources._resources import parse_method
 from civis._utils import to_camelcase
-
-from openapi_spec_validator import validate_v2_spec
 
 
 def auth_service_session(session, service_id):
     try:
         service = civis.APIClient().services.get(service_id)
     except CivisAPIError as err:
-        if err.status_code == 404:
-            msg = 'There was an issue finding service {}.'.format(service_id)
-            six.raise_from(ValueError(msg), err)
-        else:
-            raise
+        msg = ('There was an issue '
+               'finding service with ID {}.').format(service_id)
+        six.raise_from(ValueError(msg), err)
 
     auth_url = service['current_deployment']['displayUrl']
     # Make request for adding Authentication Cookie to session
@@ -83,8 +79,8 @@ class ServiceClient():
             classes = self.generate_classes()
         for class_name, klass in classes.items():
             setattr(self, class_name, klass(self._session_kwargs, client=self,
-                                          return_type=return_type,
-                                          root_path=root_path))
+                                            return_type=return_type,
+                                            root_path=root_path))
 
     def parse_path(self, path, operations):
         """ Parse an endpoint into a class where each valid http request
@@ -125,12 +121,6 @@ class ServiceClient():
             response = sess.get(swagger_url)
             response.raise_for_status()
         spec = response.json(object_pairs_hook=OrderedDict)
-        try:
-            validate_v2_spec(spec)
-        except:
-            msg = ('There was an issue validating your API spec. '
-                   'Ensure it complies with Swagger 2.0')
-            six.raise_from(ValueError(msg), ValueError)
         return spec
 
     def generate_classes(self):
@@ -143,9 +133,7 @@ class ServiceClient():
             client = civis.APIClient()
             service = client.services.get(self._service_id)
         except CivisAPIError as err:
-            if err.status_code == 404:
-                msg = ('There is no Civis Service with '
-                       'ID {}!'.format(self._service_id))
-                six.raise_from(ValueError(msg), err)
-            raise
+            msg = ('There was an issue '
+                   'finding service with ID {}.').format(service_id)
+            six.raise_from(ValueError(msg), err)
         return service['current_url']

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -41,7 +41,7 @@ class ServiceEndpoint(Endpoint):
     def _build_path(self, path):
         if not path:
             return self._client._base_url
-        if self._root_path is None:
+        if not self._root_path:
             return tostr_urljoin(self._client._base_url, path.strip("/"))
         return tostr_urljoin(self._client._base_url,
                              self._root_path.strip("/"),
@@ -130,7 +130,7 @@ class ServiceClient():
         except:
             msg = ('There was an issue validating your API spec. '
                    'Ensure it complies with Swagger 2.0')
-                six.raise_from(ValueError(msg), ValueError)
+            six.raise_from(ValueError(msg), ValueError)
         return spec
 
     def generate_classes(self):

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -55,13 +55,9 @@ class ServiceEndpoint(Endpoint):
                 response = sess.request(method, url, json=data,
                                         params=params, **kwargs)
 
-        if response.status_code == 401:
-            auth_error = response.headers["www-authenticate"]
-            six.raise_from(CivisAPIKeyError(auth_error),
-                           CivisAPIError(response))
-
         if not response.ok:
-            raise CivisAPIError(response)
+            six.raise_from(ValueError(response.text),
+                           ValueError)
 
         return response
 

--- a/civis/service_client.py
+++ b/civis/service_client.py
@@ -1,0 +1,142 @@
+import civis
+from collections import OrderedDict
+import re
+import six
+import warnings
+
+from jsonref import JsonRef
+import requests
+
+from civis.base import Endpoint, CivisAPIError, CivisAPIKeyError, tostr_urljoin
+from civis.resources._resources import parse_method
+from civis._utils import to_camelcase
+
+
+def auth_service_session(session, service_id):
+    # civis api error?
+    service = civis.APIClient().services.get(service_id)
+    auth_url = service['current_deployment']['displayUrl']
+    # Make request for Authentication Cookie
+    session.get(auth_url)
+
+
+class ServiceEndpoint(Endpoint):
+
+    def __init__(self, session_kwargs, client,
+                 return_type='civis', root_path=None):
+        self._session_kwargs = session_kwargs
+        self._return_type = return_type
+        self._client = client
+        self._root_path = root_path
+
+    def _build_path(self, path):
+        if not path:
+            return self._client._base_url
+        if self._root_path is None:
+            return tostr_urljoin(self._client._base_url, path.strip("/"))
+        return tostr_urljoin(self._client._base_url,
+                             self._root_path.strip("/"),
+                             path.strip("/"))
+
+    def _make_request(self, method, path=None, params=None, data=None,
+                      **kwargs):
+        url = self._build_path(path)
+
+        with requests.Session() as sess:
+            auth_service_session(sess, self._client._service_id)
+            with self._lock:
+                response = sess.request(method, url, json=data,
+                                        params=params, **kwargs)
+
+        if response.status_code == 401:
+            auth_error = response.headers["www-authenticate"]
+            six.raise_from(CivisAPIKeyError(auth_error),
+                           CivisAPIError(response))
+
+        if not response.ok:
+            raise CivisAPIError(response)
+
+        return response
+
+
+class ServiceClient():
+
+    def __init__(self, service_id, root_path=None, swagger_path="/endpoints"):
+        return_type = 'snake'
+        self._session_kwargs = {}
+        self._service_id = service_id
+        self._base_url = self.get_base_url()
+        self._root_path = root_path
+        self._swagger_path = swagger_path
+        # Catch deprecation warnings from generate_classes_maybe_cached and
+        # the functions it calls until the `resources` argument is removed.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=FutureWarning,
+                module='civis')
+            classes = self.generate_classes()
+        for class_name, cls in classes.items():
+            setattr(self, class_name, cls(self._session_kwargs, client=self,
+                                          return_type=return_type,
+                                          root_path=root_path))
+
+    def parse_path(self, path, operations):
+        """ Parse an endpoint into a class where each valid http request
+        on that endpoint is converted into a convenience function and
+        attached to the class as a method.
+        """
+        if self._root_path is not None:
+            path = path.replace(self._root_path, '')
+        path = path.strip('/')
+        modified_base_path = re.sub("-", "_", path.split('/')[0].lower())
+        methods = []
+        for verb, op in operations.items():
+            method = parse_method(verb, op, path)
+            if method is None:
+                continue
+            methods.append(method)
+        return modified_base_path, methods
+
+    def parse_api_spec(self, api_spec):
+        paths = api_spec['paths']
+        classes = {}
+        for path, ops in paths.items():
+            base_path, methods = self.parse_path(path, ops)
+            class_name = to_camelcase(base_path)
+            if methods and classes.get(base_path) is None:
+                classes[base_path] = type(str(class_name),
+                                          (ServiceEndpoint,),
+                                          {})
+            for method_name, method in methods:
+                setattr(classes[base_path], method_name, method)
+        return classes
+
+    def get_api_spec(self):
+        swagger_url = self._base_url + self._swagger_path
+
+        # add swagger validation ?
+
+        with requests.Session() as sess:
+            auth_service_session(sess, self._service_id)
+            response = sess.get(swagger_url)
+            response.raise_for_status()
+        spec = response.json(object_pairs_hook=OrderedDict)
+        return spec
+
+    def generate_classes(self):
+        raw_spec = self.get_api_spec()
+        spec = JsonRef.replace_refs(raw_spec)
+        return self.parse_api_spec(spec)
+
+    def get_base_url(self):
+        try:
+            client = civis.APIClient()
+            service = client.services.get(self._service_id)
+        except CivisAPIError as api_err:
+            if api_err.status_code == 404:
+                msg = ('There is no Civis Service with '
+                       'ID {}!'.format(self._service_id))
+                six.raise_from(ValueError(msg), api_err)
+            raise
+        return service['current_url']

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -111,7 +111,7 @@ def test_service_client(mock_civis, classes_mock):
     assert sc._session_kwargs == {}
     assert sc._service_id == mock_service_id
     assert sc._base_url == mock_survey_url
-    assert sc._root_path == None
+    assert sc._root_path is None
     assert sc._swagger_path == spec_endpoint
 
     # Custom root path

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -1,0 +1,254 @@
+from collections import OrderedDict
+import json
+
+from civis.service_client import ServiceClient, ServiceEndpoint
+
+from civis import response
+from civis.base import CivisAPIError
+import pytest
+from unittest import mock
+
+mock_service_id = 1
+
+mock_survey_url = "www.survey-url.com"
+
+
+@pytest.fixture
+def mock_swagger():
+    return {
+            "info": {
+                "title": "Test API Client",
+                "version": "1.0"
+            },
+            "paths": {
+                "/some-resources": {
+                    "get": {
+                        "description": "",
+                        "responses": {
+                            "200": {
+                                "description": "Returns a list",
+                            }
+                        },
+                        "summary": "List Resources",
+                        "tags": [
+                            "tag"
+                        ]
+                    }
+                },
+                "/some-resources/{id}": {
+                    "get": {
+                        "description": "",
+                        "responses": {
+                            "200": {
+                                "description": "Returns a Resource",
+                            }
+                        },
+                        "summary": "Get Resources",
+                        "tags": [
+                            "tag"
+                        ]
+                    },
+                    "patch": {
+                        "description": "",
+                        "parameters": [
+                            {
+                                "description": "The id of the Resource",
+                                "in": "path",
+                                "name": "id",
+                                "required": True,
+                                "type": "integer"
+                            },
+                            {
+                                "description": "The fields and values to edit",
+                                "in": "body",
+                                "name": "body",
+                                "required": True,
+                                "schema": {
+                                    "properties": {
+                                        "field": {
+                                            "description": "a property value",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "responses": {
+                            "200": {
+                                "description": "Edits Resource",
+                            }
+                        },
+                        "summary": "Patch Resources",
+                        "tags": [
+                            "tag"
+                        ]
+                    }
+                }
+            },
+            "swagger": "2.0"
+            }
+
+
+@pytest.fixture
+def mock_operations():
+    ops_json = mock_swagger["paths"]["/some-resources"]
+    mock_ops_str = str(ops_json).replace('\'', '\"')
+    mock_operations = json.JSONDecoder(object_pairs_hook=OrderedDict).decode(mock_ops_str)  # noqa: E501
+    return mock_operations
+
+
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_parse_path(mock_civis, classes_mock, mock_operations):
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+    classes_mock.return_value = {}
+    sc = ServiceClient(mock_service_id)
+
+    mock_path = '/some-resource/sub-resource/{id}'
+    base_path, methods = sc.parse_path(mock_path, mock_operations)
+
+    assert base_path == "some_resource"
+    assert 'get_sub_resource' in methods[0]
+
+    mock_path = '/some-resource/{id}'
+    base_path, methods = sc.parse_path(mock_path, mock_operations)
+
+    assert base_path == "some_resource"
+    assert 'get' in methods[0]
+
+
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_parse_path__with_root(mock_civis, classes_mock, mock_operations):
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+    classes_mock.return_value = {}
+    sc = ServiceClient(mock_service_id, root_path='/some-resource')
+
+    mock_path = '/some-resource/sub-resource/{id}'
+    base_path, methods = sc.parse_path(mock_path, mock_operations)
+
+    assert base_path == "sub_resource"
+    assert 'get' in methods[0]
+
+
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_parse_api_spec(mock_civis, classes_mock, mock_swagger):
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+    classes_mock.return_value = {}
+
+    sc = ServiceClient(mock_service_id)
+
+    classes = sc.parse_api_spec(mock_swagger)
+    assert 'some_resources' in classes
+
+
+@mock.patch('civis.service_client.requests.Session.get')
+@mock.patch('civis.service_client.auth_service_session')
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_get_api_spec(mock_civis, classes_mock,
+                      auth_session_mock, mock_response, mock_swagger):
+    mock_response.return_value = mock.Mock(ok=True)
+    mock_response.return_value.json.return_value = mock_swagger
+
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+    classes_mock.return_value = {}
+
+    sc = ServiceClient(mock_service_id)
+
+    spec = sc.get_api_spec()
+    assert spec == mock_swagger
+
+
+@mock.patch('civis.service_client.setattr')
+@mock.patch('civis.service_client.ServiceClient.parse_api_spec')
+@mock.patch('civis.service_client.ServiceClient.get_api_spec')
+@mock.patch('civis.service_client.civis')
+def test_generate_classes(mock_civis, api_spec_mock,
+                          parse_mock, setattr_mock, mock_swagger):
+    setattr_mock.return_value = {}
+    api_spec_mock.return_value = {}
+    mock_class_function = (lambda s, client, return_type, root_path: '/api')
+    parse_mock.return_value = {'class': mock_class_function}
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+
+    sc = ServiceClient(mock_service_id)
+
+    classes = sc.generate_classes()
+
+    assert 'class' in classes
+
+
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_get_base_url(mock_civis, classes_mock):
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.return_value = {"current_url": mock_survey_url}
+    classes_mock.return_value = {}
+
+    sc = ServiceClient(mock_service_id)
+
+    assert sc._base_url == mock_survey_url
+    mock_client.services.get.assert_called_once_with(mock_service_id)
+
+
+@mock.patch('civis.service_client.ServiceClient.generate_classes')
+@mock.patch('civis.service_client.civis')
+def test_get_base_url__not_found(mock_civis, classes_mock):
+
+    err_resp = response.Response({
+        'status_code': 404,
+        'error': 'not_found',
+        'errorDescription': 'The requested resource could not be found.',
+        'content': True})
+    err_resp.json = lambda: err_resp.json_data
+
+    mock_client = mock_civis.APIClient()
+    mock_client.services.get.side_effect = CivisAPIError(err_resp)
+    classes_mock.return_value = {}
+
+    with pytest.raises(ValueError) as excinfo:
+        ServiceClient(mock_service_id)
+
+    expected_error = f'There is no Civis Service with ID {mock_service_id}!'
+    assert str(excinfo.value) == expected_error
+
+
+def test_build_path():
+    service_client_mock = mock.Mock(_base_url='www.service_url.com')
+    se = ServiceEndpoint({}, service_client_mock)
+    path = se._build_path('/resources')
+
+    assert path == 'www.service_url.com/resources'
+
+
+def test_build_path__with_root():
+    service_client_mock = mock.Mock(_base_url='www.service_url.com')
+    se = ServiceEndpoint({}, service_client_mock, root_path='/api')
+    path = se._build_path('/resources')
+
+    assert path == 'www.service_url.com/api/resources'
+
+
+@mock.patch('civis.service_client.requests.Session.request')
+@mock.patch('civis.service_client.auth_service_session')
+@mock.patch('civis.service_client.ServiceClient.get_base_url')
+def test_make_request(mock_base_url, auth_mock, request_mock):
+    service_client_mock = mock.Mock(_base_url='www.service_url.com')
+    se = ServiceEndpoint({}, service_client_mock)
+
+    expected_value = [{'id': 1, 'url': 'www.survey_url.com/1'},
+                      {'id': 2, 'url': 'www.survey_url.com/2'}]
+
+    request_mock.return_value = mock.Mock(ok=True)
+    request_mock.return_value.json = expected_value
+
+    response = se._make_request('get', 'resources/resources')
+
+    assert response.json == expected_value

--- a/civis/tests/test_service_client.py
+++ b/civis/tests/test_service_client.py
@@ -106,11 +106,13 @@ def test_service_client(mock_civis, classes_mock):
 
     sc = ServiceClient(mock_service_id)
 
+    spec_endpoint = "/endpoint"
+
     assert sc._session_kwargs == {}
     assert sc._service_id == mock_service_id
     assert sc._base_url == mock_survey_url
     assert sc._root_path == None
-    assert sc._swagger_path == "/endpoints"
+    assert sc._swagger_path == spec_endpoint
 
     # Custom root path
     sc = ServiceClient(mock_service_id, root_path='/api')


### PR DESCRIPTION
Adding ServiceClient() method which takes a service id, optional base path, and optional swagger endpoint, then creates a client from the api spec and endpoints.

I'm still working on testing but I'm not planning on changing much else from here so I thought it would be a good time for initial review.

A lot of the work is being done in the helper functions and Endpoint class for the original APIClient, but small changes were needed in a few cases. These changes are override-ed by the ServiceClient and ServiceEndpoint class.